### PR TITLE
Fix logging typo and improve bucket path splitting

### DIFF
--- a/ingestor/app/main.py
+++ b/ingestor/app/main.py
@@ -23,7 +23,7 @@ def ingest_data(destination_path: str) -> None:
     sources = get_page_sources(is_test_mode)
     data_gen = build_data_gen(sources)
     write_data(data_gen, destination_path, is_test_mode)
-    logging.info("✅ Successfully ingested data}")
+    logging.info("✅ Successfully ingested data")
 
 
 if __name__ == "__main__":

--- a/ingestor/app/writer.py
+++ b/ingestor/app/writer.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 def write_data(data_gen: Generator[pd.DataFrame, None, None], destination_bucket: str, test_mode: bool):
-    bucket_name, bucket_key = destination_bucket.replace("gs://", "").split("/")
+    bucket_name, bucket_key = destination_bucket.replace("gs://", "").split("/", 1)
     if test_mode:
         write_pandas_to_local_csv(data_gen, bucket_key)
     else:


### PR DESCRIPTION
## Summary
- fix logging message typo in ingestor main
- handle nested bucket paths correctly when writing data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest -q` in ingestor *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68400927b77c8331a5eed0f4bc3f14bb